### PR TITLE
Support TTS on linux

### DIFF
--- a/PoetAssistant.pro
+++ b/PoetAssistant.pro
@@ -29,3 +29,9 @@ macx:{
     ttsosxplugin.depends = tts
     app.depends += ttsosxplugin
 }
+linux-g++ {
+    SUBDIRS += ttslinuxplugin
+    ttslinuxplugin.file=lib/qtspeech/src/plugins/tts/speechdispatcher/speechdispatcher.pro
+    ttslinuxplugin.depends = tts
+    app.depends +=  ttslinuxplugin
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # Poet Assistant (Desktop version)
 
-## Building
-This has only been tested on MacOS for now.
+## Installing
+* Download the application binary from the [releases](https://github.com/caarmen/poet-assistant-desktop/releases) page
+* Linux: For text-to-speech features to be available, install `speech-dispatcher`
 
+## Building
 * Install [Qt](https://qt.io)
-* Run `qmake`
-* Run `make`
-* Open the application in `build/out/PoetAssistant.app`
+* Install additional dependencies:
+  - Linux: `speech-dispatcher`, `libspeechd-dev`
+* Run the appropriate build script for your platform:
+  - `bash deploy/linux.bash`
+  - `bash deploy/mac.bash`
+  - `deploy\windows.bat`
+* The application is created in `app/build/out`
+

--- a/app/resources/qml.qrc
+++ b/app/resources/qml.qrc
@@ -38,5 +38,6 @@
         <file>qml/TabButtonView.qml</file>
         <file>images/stop.svg</file>
         <file>qml/TtsControlsView.qml</file>
+        <file>qml/ResizingComboBox.qml</file>
     </qresource>
 </RCC>

--- a/app/resources/qml/ResizingComboBox.qml
+++ b/app/resources/qml/ResizingComboBox.qml
@@ -1,0 +1,43 @@
+/**
+Copyright (c) 2022 - present Carmen Alvarez
+
+This file is part of Poet Assistant.
+
+Poet Assistant is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Poet Assistant is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Poet Assistant.  If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ComboBox {
+    Component.onCompleted: resize()
+    onModelChanged: resize()
+    onVisibleChanged: {
+        if (visible) resize()
+    }
+
+    TextMetrics {
+        id: textMetrics
+    }
+    function resize() {
+        textMetrics.font = font
+        var modelWidth = 0
+        for(var i = 0; i < model.length; i++){
+            textMetrics.text = model[i]
+            modelWidth = Math.max(textMetrics.width, modelWidth)
+        }
+        Layout.minimumWidth = modelWidth + implicitIndicatorWidth + leftPadding + rightPadding
+    }
+
+}

--- a/app/resources/qml/TtsControlsView.qml
+++ b/app/resources/qml/TtsControlsView.qml
@@ -44,7 +44,7 @@ RowLayout{
             color: Style.primaryText
             text: qsTr("label_voice");
         }
-        ComboBox {
+        ResizingComboBox {
             id: cbVoices
             palette.dark: Style.primary
             model: ttsViewModel.availableVoiceNames

--- a/app/resources/qml/TtsControlsView.qml
+++ b/app/resources/qml/TtsControlsView.qml
@@ -86,9 +86,9 @@ RowLayout{
         }
         Slider {
             id: ttsPitch
-            from: -1
+            from: ttsViewModel.minPitch
             value: ttsViewModel.pitch
-            to: 10
+            to: ttsViewModel.maxPitch
             onMoved: ttsViewModel.pitch = value
             Connections {
                 target: ttsViewModel
@@ -103,9 +103,9 @@ RowLayout{
         }
         Slider {
             id: ttsRate
-            from: -0.5
-            value: 0
-            to: 1
+            from: ttsViewModel.minRate
+            value: ttsViewModel.rate
+            to: ttsViewModel.maxRate
             onMoved: ttsViewModel.rate = value
             Connections {
                 target: ttsViewModel

--- a/app/resources/qml/TtsControlsView.qml
+++ b/app/resources/qml/TtsControlsView.qml
@@ -48,13 +48,11 @@ RowLayout{
             id: cbVoices
             palette.dark: Style.primary
             model: ttsViewModel.availableVoiceNames
-            Component.onCompleted: currentIndex = indexOfValue(ttsViewModel.voiceName)
+            Component.onCompleted: reselectVoice()
             onActivated: ttsViewModel.useVoice(currentValue)
-            Connections {
-                target: ttsViewModel
-                function onVoiceNameChanged() {
-                    cbVoices.currentIndex = cbVoices.indexOfValue(ttsViewModel.voiceName)
-                }
+            onModelChanged: reselectVoice()
+            function reselectVoice() {
+                currentIndex = indexOfValue(ttsViewModel.voiceName)
             }
         }
     }

--- a/app/src/main/viewmodel/ttsviewmodel.cpp
+++ b/app/src/main/viewmodel/ttsviewmodel.cpp
@@ -44,7 +44,11 @@ QStringList TtsViewModel::getAvailableVoiceNames() const {
     QStringList voiceNames = QtConcurrent::blockingMapped(tts->availableVoices(), [=] (QVoice voice) {
         return voice.name();
     });
+    QString selectedVoiceName = getVoiceName();
     voiceNames.sort();
+    if (!voiceNames.contains(selectedVoiceName)) {
+        voiceNames.prepend(selectedVoiceName);
+    }
     return voiceNames;
 }
 void TtsViewModel::useVoice(QString name) {

--- a/app/src/main/viewmodel/ttsviewmodel.h
+++ b/app/src/main/viewmodel/ttsviewmodel.h
@@ -2,6 +2,7 @@
 #define TTSVIEWMODEL_H
 
 #include <QObject>
+#include <QtGlobal>
 #include <QtTextToSpeech/qtexttospeech.h>
 
 class TtsViewModel : public QObject
@@ -12,6 +13,10 @@ class TtsViewModel : public QObject
     Q_PROPERTY(QString voiceName READ getVoiceName() NOTIFY voiceNameChanged)
     Q_PROPERTY(QStringList availableVoiceNames READ getAvailableVoiceNames() NOTIFY availableVoiceNamesChanged)
     Q_PROPERTY(QString playButtonIcon READ getPlayButtonIcon NOTIFY playButtonIconChanged)
+    Q_PROPERTY(double minPitch MEMBER minPitch CONSTANT)
+    Q_PROPERTY(double maxPitch MEMBER maxPitch CONSTANT)
+    Q_PROPERTY(double minRate MEMBER minRate CONSTANT)
+    Q_PROPERTY(double maxRate MEMBER maxRate CONSTANT)
 
 public:
     explicit TtsViewModel(QObject *parent = nullptr);
@@ -39,6 +44,18 @@ private:
     QString getPlayButtonIcon();
     QTextToSpeech *tts;
     QList<QString> localeNames;
+
+#ifdef Q_OS_MACOS
+    const static inline double minPitch = -1;
+    const static inline double maxPitch = 10;
+    const static inline double minRate = -0.5;
+    const static inline double maxRate = 1;
+#else
+    const static inline double minPitch = -1;
+    const static inline double maxPitch = 1;
+    const static inline double minRate = -0.99;
+    const static inline double maxRate = 1;
+#endif
 };
 
 #endif // TTSVIEWMODEL_H

--- a/deploy/linux.bash
+++ b/deploy/linux.bash
@@ -28,6 +28,9 @@ build_folder=app/build/out
 temp_folder=$(mktemp --directory -t poet-assistant-XXXXXXXXXX)
 
 function build {
+    cd lib/qtspeech
+    qmake
+    cd -
     qmake VERSION=$version
     make
 }
@@ -41,7 +44,7 @@ function updateRpath {
     chrpath -r '$ORIGIN/dependencies/lib' $copied_program
 }
 
-function copyDependencies {
+function copyQtDependencies {
     echo "Copying dependencies..."
     libs=( \
         libQt6Concurrent.so.6 \
@@ -145,6 +148,11 @@ function copyDependencies {
     done
 }
 
+function copyLocalDependencies {
+    tts_plugin_folder=$dependencies_folder/plugins/texttospeech
+    mkdir -p $tts_plugin_folder
+    cp lib/qtspeech/plugins/texttospeech/libqtexttospeech_speechd.so $tts_plugin_folder/.
+}
 function createArchive {
     output_file=${build_folder}/PoetAssistant-linux-$version.tgz
     echo "Creating ${output_file}..."
@@ -154,7 +162,8 @@ function createArchive {
 }
 
 build
-copyDependencies
+copyQtDependencies
+copyLocalDependencies
 copyProgram
 updateRpath
 createArchive


### PR DESCRIPTION
* Build the speech dispatcher tts plugin
* Update the build script to include this plugin in the final binary archive
* Update some app behavior so that tts works better on linux:
    - Set min/max bounds for speech speed/pitch, based on platform
    - Resize the voice name combobox (on mac the voice names were very short, but they're longer on linux)
    - Show the selected voice name if it's not in the list of voices. On linux the initially selected voice name is "Default", which isn't in the list of voices
* Update the README with build and install instructions for all platforms