### PR TITLE
Package the database file, not as a qml resource

### DIFF
--- a/app/app.pro
+++ b/app/app.pro
@@ -140,12 +140,34 @@ QMAKE_EXTRA_TARGETS += dmgfile
 RC_ICONS = ../deploy/config/icon.ico
 ICON = ../deploy/icon.icns
 
+# Package the database file
+BUILD_DIR=$$shadowed($$PWD)/build/out/
+DB_SOURCE_PATH = $$shell_path($$PWD/resources/poet_assistant.db)
+macx{
+    DB_TARGET_FOLDER = $$shell_path($${BUILD_DIR}/$${TARGET}.app/Contents/Resources)
+    DEFINES += DB_FOLDER=\\\"../Resources\\\"
+} else {
+    DB_TARGET_FOLDER = $$shell_path($${BUILD_DIR})
+    DEFINES += DB_FOLDER=\\\"\\\"
+}
+dbTargetFolder.target = $${DB_TARGET_FOLDER}
+win32 {
+    dbTargetFolder.commands = $(CHK_DIR_EXISTS) $${DB_TARGET_FOLDER} $(MKDIR) $${DB_TARGET_FOLDER}
+} else {
+    dbTargetFolder.commands = $(MKDIR) $${DB_TARGET_FOLDER}
+}
+
+dbTargetFile.depends = dbTargetFolder
+dbTargetFile.target = $${DB_TARGET_FOLDER}/poet_assistant.db
+dbTargetFile.commands = $(COPY_FILE) $${DB_SOURCE_PATH} $${DB_TARGET_FOLDER}
+QMAKE_EXTRA_TARGETS += dbTargetFolder dbTargetFile
+PRE_TARGETDEPS += $${dbTargetFile.target}
+
 # TextToSpeech
 QTSPEECH_DIR=$$PWD/../lib/qtspeech
 LIBS += -L$${QTSPEECH_DIR}/lib/  -lQt6TextToSpeech
 INCLUDEPATH += $${QTSPEECH_DIR}/include
 macx:{
-    BUILD_DIR=$$shadowed($$PWD)/build/out/
     TARGET_PATH=$${BUILD_DIR}/$${TARGET}.app
 
     QtSpeechOsxPlugin.target = $${TARGET_PATH}/Contents/Plugins/texttospeech/libqtexttospeech_speechosx.dylib

--- a/app/resources/qml.qrc
+++ b/app/resources/qml.qrc
@@ -16,7 +16,6 @@
         <file>images/star.svg</file>
         <file>images/star_border.svg</file>
         <file>images/stop.svg</file>
-        <file>poet_assistant.db</file>
         <file>qml/AboutDialog.qml</file>
         <file>qml/ComposerTabView.qml</file>
         <file>qml/DefinitionListItemDelegate.qml</file>

--- a/app/src/main/repository/db.cpp
+++ b/app/src/main/repository/db.cpp
@@ -35,19 +35,11 @@ QFuture<void> Db::openDb()
     return QtConcurrent::run(threadPool, [ = ]() {
         QSqlDatabase db = QSqlDatabase::addDatabase("QSQLITE");
         db.setConnectOptions("QSQLITE_OPEN_READONLY");
-        QFile file(":/poet_assistant.db");
-        //QFile file("../../../../../../../poet-assistant-desktop/app/resources/poet_assistant.db");
-        QString appDataDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-        QDir().mkpath(appDataDir);
-        QString dbCopyFileName = QFileInfo(appDataDir, "poet_assistant.db").absoluteFilePath();
-        QFile dbCopyFile(dbCopyFileName);
-        if (dbCopyFile.open(QIODevice::WriteOnly)) {
-            if (file.open(QIODevice::ReadOnly)) {
-                dbCopyFile.write(file.readAll());
-            }
-            dbCopyFile.close();
-        }
-        db.setDatabaseName(dbCopyFile.fileName());
+        QString appDir = QCoreApplication::applicationDirPath();
+        QString dbFolder = QString(DB_FOLDER);
+        if (!dbFolder.isEmpty()) appDir = QFileInfo(appDir, dbFolder).absoluteFilePath();
+        QFileInfo dbFileInfo = QFileInfo(appDir, "poet_assistant.db");
+        db.setDatabaseName(dbFileInfo.absoluteFilePath());
         if (!db.open()) {
             qFatal("Couldn't open db");
         }

--- a/deploy/linux.bash
+++ b/deploy/linux.bash
@@ -152,12 +152,14 @@ function copyLocalDependencies {
     tts_plugin_folder=$dependencies_folder/plugins/texttospeech
     mkdir -p $tts_plugin_folder
     cp lib/qtspeech/plugins/texttospeech/libqtexttospeech_speechd.so $tts_plugin_folder/.
+
+    cp $build_folder/poet_assistant.db $temp_folder/
 }
 function createArchive {
     output_file=${build_folder}/PoetAssistant-linux-$version.tgz
     echo "Creating ${output_file}..."
     rm -f $output_file
-    tar czf $output_file -C $temp_folder $program_file_name dependencies
+    tar czf $output_file -C $temp_folder $program_file_name poet_assistant.db dependencies
     echo "created $output_file"
 }
 

--- a/deploy/windows.bat
+++ b/deploy/windows.bat
@@ -50,7 +50,7 @@ cd %project_folder%
 
 mingw32-make release
 
-windeployqt --qmldir=. --qmlimport=. %output_folder%\PoetAssistant.exe
+windeployqt --qmldir=%app_folder% --qmlimport=%app_folder% %output_folder%\PoetAssistant.exe
 
 echo Building archive...
 copy deploy\config\icon.ico %output_folder%\icon.ico


### PR DESCRIPTION
Including the db file in qml resources made the builds very slow, and required lots of memory.
We can instead package the db file along with the executable.

Also: Make windeployqt faster by scanning app folder